### PR TITLE
Add types declaration file in src directory

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,110 @@
+declare module 'iterable-async' {
+	class AsyncArray<T = any> extends Array {
+		static from<T>(iterable: Iterable<T> | ArrayLike<T>): AsyncArray<T>;
+
+		static from<T, U>(
+			iterable: Iterable<T> | ArrayLike<T>,
+			mapfn: (v: T, k: number) => U,
+			thisArg?: any
+		): AsyncArray<U>;
+
+		asyncFilter(
+			callback: (
+				currentValue: any,
+				index?: number,
+				array?: Array<any>
+			) => void,
+			thisArg?: ThisParameterType<AsyncArray> | Symbol
+		): Promise<AsyncArray>;
+
+		asyncFind(
+			callback: (
+				currentValue: any,
+				index?: number,
+				array?: Array<any>
+			) => void,
+			thisArg?: ThisParameterType<AsyncArray> | Symbol
+		): Promise<any>;
+
+		asyncFindIndex(
+			callback: (
+				currentValue: any,
+				index?: number,
+				array?: Array<any>
+			) => void,
+			thisArg?: ThisParameterType<AsyncArray> | Symbol
+		): Promise<number>;
+
+		asyncForEach(
+			callback: (
+				currentValue: any,
+				index?: number,
+				array?: Array<any>
+			) => void,
+			thisArg?: ThisParameterType<AsyncArray> | Symbol
+		): Promise<void>;
+
+		asyncMap(
+			callback: (
+				currentValue: any,
+				index?: number,
+				array?: Array<any>
+			) => void,
+			thisArg?: ThisParameterType<AsyncArray> | Symbol
+		): Promise<AsyncArray>;
+
+		asyncSort(
+			compareFunc?: (leftItem: any, pivot: any) => any
+		): Promise<AsyncArray>;
+	}
+
+	// Due to the way this package is structured, the functions have to be defined twice.
+	export function asyncFilter(
+		callback: (
+			currentValue: any,
+			index?: number,
+			array?: Array<any>
+		) => void,
+		thisArg?: ThisParameterType<AsyncArray> | Symbol
+	): Promise<AsyncArray>;
+
+	export function asyncFind(
+		callback: (
+			currentValue: any,
+			index?: number,
+			array?: Array<any>
+		) => void,
+		thisArg?: ThisParameterType<AsyncArray> | Symbol
+	): Promise<any>;
+
+	export function asyncFindIndex(
+		callback: (
+			currentValue: any,
+			index?: number,
+			array?: Array<any>
+		) => void,
+		thisArg?: ThisParameterType<AsyncArray> | Symbol
+	): Promise<number>;
+
+	export function asyncForEach(
+		callback: (
+			currentValue: any,
+			index?: number,
+			array?: Array<any>
+		) => void,
+		thisArg?: ThisParameterType<AsyncArray> | Symbol
+	): Promise<void>;
+
+	export function asyncMap(
+		callback: (
+			currentValue: any,
+			index?: number,
+			array?: Array<any>
+		) => void,
+		thisArg?: ThisParameterType<AsyncArray> | Symbol
+	): Promise<AsyncArray>;
+
+	export function asyncSort(
+		compareFunc?: (leftItem: any, pivot: any) => any
+	): Promise<AsyncArray>;
+}


### PR DESCRIPTION
I've written up the types declaration file as promised.

However, as you will notice (and I've left a comment about it for future reference), the functions / class methods have been needed to be written up twice because I cannot append each function to the class' prototype without defining them inside the class first, which then needs parameter and return types to be defined as well.

The solution to this would be to either go with the `const arr = new AsyncArray('val1', 'val2')` approach or the static method approach, where `AsyncArray` is a class you don't instantiate and use instead like `AsyncArray.asyncMap((curVal, 0, ['hello', 'world']) => ...).then(...)`.

But that is if you'd like to make this types declaration file more maintainable in the future. It works, but the definitions just had to be written in two separate forms to match the two separate approaches of the package.

Hope you find this file to be to your liking. Any further issues, let me know.